### PR TITLE
Fix file rejection issues

### DIFF
--- a/ImageExtra.module
+++ b/ImageExtra.module
@@ -127,7 +127,7 @@ class ImageExtra extends WireData implements Module, ConfigurableModule {
         if (wire('page')->name === 'field' || !empty($this->additionalFields)) {
           $this->addHookAfter('InputfieldFile::processInputFile', $this, 'processInputFileExtra');
           $this->addHookBefore('InputfieldFile::processInputAddFile', $this, 'processInputAddFileExtra');
-          $this->addHookBefore('InputfieldFile::fileAdded', $this, 'fileAddedExtra');
+          $this->addHookAfter('InputfieldImage::fileAdded', $this, 'fileAddedExtra');
           $this->addHookAfter('Fieldtype::loadPageField', $this, 'loadPageFieldExtra');
           $this->addHookAfter('FieldtypeFile::sleepValue', $this, 'sleepExtraValue');
           $this->addHookAfter('FieldtypeFile::wakeupValue', $this, 'wakeupExtraValue');


### PR DESCRIPTION
If you have for example a minimum size defined and the added image causes an error your code will save the image even thought the original method will reject it afterwards. This is resulting in 0x0 images being safed to the database while the file will be unlink'ed. (ProcessWire will tell that it is unable to display the image)
