### PR TITLE
Check for existence of $page->data['title']

### DIFF
--- a/ImageExtra.module
+++ b/ImageExtra.module
@@ -520,7 +520,7 @@ class ImageExtra extends WireData implements Module {
   public function formatExtraValue(HookEvent $event) {
     $page = $event->arguments(0);
 
-    if ($page->data['title']) {
+    if (!empty($page->data['title'])) {
       $field = $event->arguments(1);
       $value = $event->arguments(2);
       $settings = $this->getOtherFieldSettings($field);


### PR DESCRIPTION
If the page has no title, a pesky notice is thrown - think of page tables childs which are configured to have no title field. This small patch fixes that and does no harm :)